### PR TITLE
Fix for failing frontend CI/CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,14 @@ jobs:
         working-directory: frontend
       - run: yarn build
         working-directory: frontend
+        env:
+          NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
+          NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{ secrets.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN }}
+          NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_PROJECT_ID }}
+          NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ${{ secrets.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET }}
+          NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID }}
+          NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
+          NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID }}
 
   build-questions:
     needs: changes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
+      - uses: actions/cache@v2
+        with:
+          path: frontend/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - run: yarn install
         working-directory: frontend
       - run: yarn build

--- a/frontend/src/app/admin/question/page.tsx
+++ b/frontend/src/app/admin/question/page.tsx
@@ -35,7 +35,7 @@ interface FetchQuestionResponse {
   statusMessage: string;
 }
 
-const Table = dynamic(() => import("antd/lib/Table"), {
+const Table = dynamic(() => import("antd/lib").then((m) => m.Table), {
   ssr: false,
   loading: () => (
     <Skeleton


### PR DESCRIPTION
Named imports are [not allowed](https://nextjs.org/docs/pages/building-your-application/optimizing/lazy-loading#with-named-exports) in dynamic imports, in both Next and in Javascript as a whole I believe.

Switched to using the recommended import step using `.then()`.
